### PR TITLE
Add EC2 instance example

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"  # Adjust as needed
+}
+
+resource "aws_instance" "example" {
+  ami           = "ami-0c55b159cbfafe1f0"  # Amazon Linux 2 AMI
+  instance_type = "t2.micro"
+
+  tags = {
+    Name = "example-instance"
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform example that provisions an EC2 instance

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685915fb3b588325ad289e4d89c1c7ae